### PR TITLE
fix: rewrite useThrottle with leading-edge semantics

### DIFF
--- a/.changeset/fix-throttle-semantics.md
+++ b/.changeset/fix-throttle-semantics.md
@@ -1,0 +1,11 @@
+---
+"@julianfere/hooked": minor
+---
+
+`useThrottle` now implements true leading-edge + trailing throttle semantics.
+
+Previously, every value change reset the delay timer (debounce-like behavior — all changes were always delayed). Now:
+- The **first** value change in a new throttle window passes through **immediately** (leading edge).
+- Subsequent rapid changes within the interval are held back and only the **last** value is applied after the remaining window time (trailing).
+
+**Migration:** If you relied on the previous behavior where the first change was always delayed, add an explicit `useDebounce` instead.

--- a/src/useThrottle/index.test.tsx
+++ b/src/useThrottle/index.test.tsx
@@ -14,7 +14,7 @@ describe("useThrottle", () => {
     vi.useRealTimers();
   });
 
-  it("should return the value immediately", () => {
+  it("should return the initial value immediately", () => {
     const { result } = renderHook(
       (props: UseThrottleProps) => useThrottle(props.value),
       {
@@ -25,7 +25,7 @@ describe("useThrottle", () => {
     expect(result.current).toBe(0);
   });
 
-  it("should return the value after the delay", () => {
+  it("should pass the first value change through immediately (leading edge)", () => {
     const { result, rerender } = renderHook(
       (props: UseThrottleProps) => useThrottle(props.value, props.delay),
       {
@@ -37,16 +37,36 @@ describe("useThrottle", () => {
 
     rerender({ value: 1, delay: 1000 });
 
+    // Leading edge: first change should pass immediately without waiting
+    expect(result.current).toBe(1);
+  });
+
+  it("should throttle rapid updates and apply the last value after the interval", () => {
+    const { result, rerender } = renderHook(
+      (props: UseThrottleProps) => useThrottle(props.value, props.delay),
+      {
+        initialProps: { value: 0, delay: 1000 },
+      }
+    );
+
+    // Leading edge: first change passes immediately
     rerender({ value: 1, delay: 1000 });
+    expect(result.current).toBe(1);
+
+    // Subsequent rapid changes within the interval are throttled
     rerender({ value: 2, delay: 1000 });
     rerender({ value: 3, delay: 1000 });
 
+    // Still 1 — changes 2 and 3 are held back
+    expect(result.current).toBe(1);
+
+    // After the interval, last value (3) is applied
     act(() => vi.advanceTimersByTime(1000));
 
     expect(result.current).toBe(3);
   });
 
-  it("should use the default delay", () => {
+  it("should use the default interval", () => {
     const { result, rerender } = renderHook(
       (props: UseThrottleProps) => useThrottle(props.value, props.delay),
       {
@@ -56,17 +76,15 @@ describe("useThrottle", () => {
 
     expect(result.current).toBe(0);
 
+    // Leading edge: first change passes immediately
     rerender({ value: 1 });
-
-    act(() => vi.advanceTimersByTime(500));
-
     expect(result.current).toBe(1);
 
-    rerender({ value: 1 });
+    // Rapid updates within default 500ms interval are throttled
     rerender({ value: 2 });
     rerender({ value: 3 });
 
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(500));
 
     expect(result.current).toBe(3);
   });

--- a/src/useThrottle/index.tsx
+++ b/src/useThrottle/index.tsx
@@ -3,18 +3,29 @@ import { useEffect, useRef, useState } from "react";
 const useThrottle = <T,>(value: T, interval = 500): T => {
   const [throttledValue, setThrottledValue] = useState(value);
   const lastUpdated = useRef<number | null>(null);
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
-    const now = Date.now();
+    // Skip initial mount — initial value is already set via useState
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
 
-    if (lastUpdated.current && now >= lastUpdated.current + interval) {
+    const now = Date.now();
+    const elapsed = lastUpdated.current !== null ? now - lastUpdated.current : Infinity;
+
+    if (elapsed >= interval) {
+      // Leading edge: first change in a new window passes through immediately
       lastUpdated.current = now;
       setThrottledValue(value);
     } else {
+      // Trailing: schedule the last value for the remaining time in the window
+      const remaining = interval - elapsed;
       const id = setTimeout(() => {
-        lastUpdated.current = now;
+        lastUpdated.current = Date.now();
         setThrottledValue(value);
-      }, interval);
+      }, remaining);
 
       return () => clearTimeout(id);
     }


### PR DESCRIPTION
Previous implementation was debounce-like (every change reset the timer). Now uses leading + trailing throttle: first change passes immediately, subsequent rapid changes are held back until end of interval window.