### PR TITLE
feat: overhaul useAsync with discriminated union state and richer API

### DIFF
--- a/.changeset/feat-useAsync-overhaul.md
+++ b/.changeset/feat-useAsync-overhaul.md
@@ -1,0 +1,43 @@
+---
+"@julianfere/hooked": minor
+---
+
+**`useAsync` overhaul** — richer API, proper state machine, no more stale closures.
+
+### Breaking changes
+
+- `run` renamed to `trigger`
+- `manual` option removed — the default behavior is now manual (call `trigger()` yourself). Use `immediate: true` to run on mount.
+- `cancelable` option removed — in-flight requests are always cancelled when `trigger` is called again or the component unmounts
+- `state` (string) replaced by `status` (same string values: `"idle" | "pending" | "fulfilled" | "rejected"`)
+- `AsyncStatus` enum no longer exported — use the string literals directly
+
+### New return values
+
+- `data: T | undefined` — the resolved value, available when `status === "fulfilled"`
+- `error: unknown` — the thrown value, available when `status === "rejected"`
+- `loading: boolean` — shorthand for `status === "pending"`
+- `reset()` — resets back to `idle` and cancels any in-flight request
+
+### State is now a discriminated union
+
+TypeScript narrows `data` and `error` correctly based on `status`:
+```ts
+const { status, data, error } = useAsync(fetchUser);
+if (status === "fulfilled") console.log(data); // data: User
+if (status === "rejected")  console.log(error); // error: unknown
+```
+
+### Migration
+
+```ts
+// before
+const { run, state } = useAsync(fn, { manual: true });
+run(id);
+if (state === "fulfilled") { /* no data available */ }
+
+// after
+const { trigger, status, data } = useAsync(fn);
+trigger(id);
+if (status === "fulfilled") { console.log(data); }
+```

--- a/src/useAsync/index.test.tsx
+++ b/src/useAsync/index.test.tsx
@@ -13,101 +13,177 @@ describe("useAsync", () => {
     vi.restoreAllMocks();
   });
 
-  it("return runner and state", () => {
-    const asyncFunction = (arg: string) => Promise.resolve(arg);
-
+  it("returns trigger, reset, status, data, error and loading", () => {
     const { result } = renderHook(() =>
-      useAsync((arg: string) => asyncFunction(arg))
+      useAsync((arg: string) => Promise.resolve(arg))
     );
 
-    expect(result.current.run).toBeDefined();
-    expect(result.current.state).toBeDefined();
+    expect(result.current.trigger).toBeInstanceOf(Function);
+    expect(result.current.reset).toBeInstanceOf(Function);
+    expect(result.current.status).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.loading).toBe(false);
   });
 
-  it("should return idle when manual is true and the runner is not called", async () => {
-    const asyncFunction = (arg: string) => Promise.resolve(arg);
-
+  it("starts in idle state", () => {
     const { result } = renderHook(() =>
-      useAsync((arg: string) => asyncFunction(arg), { manual: true })
+      useAsync((arg: string) => Promise.resolve(arg))
     );
 
-    expect(result.current.state).toBe("idle");
+    expect(result.current.status).toBe("idle");
   });
 
-  it("should trun the async function and return the correct status", async () => {
+  it("transitions to pending while running", async () => {
     const asyncFunction = (arg: string) =>
       new Promise<string>((resolve) => setTimeout(() => resolve(arg), 1000));
 
-    const { result } = renderHook(() =>
-      useAsync((arg: string) => asyncFunction(arg), { manual: true })
-    );
+    const { result } = renderHook(() => useAsync(asyncFunction));
 
     await act(async () => {
-      result.current.run("test");
+      result.current.trigger("test");
+    });
+
+    expect(result.current.status).toBe("pending");
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("transitions to fulfilled and exposes data", async () => {
+    const asyncFunction = (arg: string) =>
+      new Promise<string>((resolve) => setTimeout(() => resolve(arg), 1000));
+
+    const { result } = renderHook(() => useAsync(asyncFunction));
+
+    await act(async () => {
+      result.current.trigger("hello");
       vi.advanceTimersByTime(1000);
     });
-    expect(result.current.state).toBe("fulfilled");
+
+    expect(result.current.status).toBe("fulfilled");
+    expect(result.current.data).toBe("hello");
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.loading).toBe(false);
   });
 
-  it('should return "pending" when the async function is running', async () => {
-    const asyncFunction = (arg: string) =>
-      new Promise<string>((resolve) => setTimeout(() => resolve(arg), 1000));
+  it("transitions to rejected and exposes error", async () => {
+    const asyncFunction = () => Promise.reject(new Error("boom"));
 
-    const { result } = renderHook(() =>
-      useAsync((arg: string) => asyncFunction(arg), { manual: true })
-    );
+    const { result } = renderHook(() => useAsync(asyncFunction));
+
     await act(async () => {
-      result.current.run("test");
+      result.current.trigger();
+      vi.advanceTimersByTime(1000);
     });
-    expect(result.current.state).toBe("pending");
+
+    expect(result.current.status).toBe("rejected");
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe("boom");
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.loading).toBe(false);
   });
 
-  it("should throw an error when the runner is called and manual is false", () => {
-    const asyncFunction = (arg: string) => Promise.resolve(arg);
+  it("resets back to idle state", async () => {
+    const asyncFunction = () => Promise.resolve("data");
+
+    const { result } = renderHook(() => useAsync(asyncFunction));
+
+    await act(async () => {
+      result.current.trigger();
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.status).toBe("fulfilled");
+
+    act(() => result.current.reset());
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("cancels a previous in-flight request when trigger is called again", async () => {
+    let callCount = 0;
+    const asyncFunction = () =>
+      new Promise<number>((resolve) =>
+        setTimeout(() => resolve(++callCount), 1000)
+      );
+
+    const { result } = renderHook(() => useAsync(asyncFunction));
+
+    await act(async () => {
+      result.current.trigger(); // first call
+    });
+
+    await act(async () => {
+      result.current.trigger(); // cancels first, starts second
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Only the second result should land
+    expect(result.current.status).toBe("fulfilled");
+    expect(result.current.data).toBe(2);
+  });
+
+  it("runs automatically on mount when immediate is true", async () => {
+    const asyncFunction = () => Promise.resolve("auto");
 
     const { result } = renderHook(() =>
-      useAsync((arg: string) => asyncFunction(arg))
+      useAsync(asyncFunction, { immediate: true })
     );
 
-    expect(() => result.current.run("test")).toThrowError(
-      "run() is only available when the manual option is set to true"
-    );
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.status).toBe("fulfilled");
+    expect(result.current.data).toBe("auto");
   });
 
-  it("should call the onSuccess handler when the async function resolves", async () => {
-    const asyncFunction = () => Promise.resolve("Success");
+  it("calls onSuccess with the result", async () => {
     const onSuccess = vi.fn();
+    const asyncFunction = () => Promise.resolve("value");
 
     const { result } = renderHook(() =>
-      useAsync(() => asyncFunction(), {
-        onSuccess: (data) => onSuccess(data),
-        manual: true,
-      })
+      useAsync(asyncFunction, { onSuccess })
     );
 
     await act(async () => {
-      result.current.run();
+      result.current.trigger();
       vi.advanceTimersByTime(1000);
     });
 
-    expect(onSuccess).toBeCalledWith("Success");
-    expect(result.current.state).toBe("fulfilled");
+    expect(onSuccess).toHaveBeenCalledWith("value");
   });
 
-  it("should call the latest onSuccess callback even after rerender", async () => {
+  it("calls onError with the thrown error", async () => {
+    const onError = vi.fn();
+    const asyncFunction = () => Promise.reject("oops");
+
+    const { result } = renderHook(() =>
+      useAsync(asyncFunction, { onError })
+    );
+
+    await act(async () => {
+      result.current.trigger();
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(onError).toHaveBeenCalledWith("oops");
+  });
+
+  it("calls the latest onSuccess callback after a rerender", async () => {
     const onSuccessV1 = vi.fn();
     const onSuccessV2 = vi.fn();
 
-    const { rerender, result } = renderHook(
-      ({ cb }) =>
-        useAsync(() => Promise.resolve("data"), { onSuccess: cb, manual: true }),
+    const { result, rerender } = renderHook(
+      ({ cb }) => useAsync(() => Promise.resolve("data"), { onSuccess: cb }),
       { initialProps: { cb: onSuccessV1 } }
     );
 
     rerender({ cb: onSuccessV2 });
 
     await act(async () => {
-      result.current.run();
+      result.current.trigger();
       vi.advanceTimersByTime(1000);
     });
 
@@ -115,11 +191,11 @@ describe("useAsync", () => {
     expect(onSuccessV2).toHaveBeenCalledWith("data");
   });
 
-  it("should not call onSuccess after unmount", async () => {
+  it("does not call onSuccess after unmount", async () => {
     const onSuccess = vi.fn();
 
     const { unmount } = renderHook(() =>
-      useAsync(() => Promise.resolve("data"), { onSuccess, manual: true })
+      useAsync(() => Promise.resolve("data"), { onSuccess })
     );
 
     unmount();
@@ -129,25 +205,5 @@ describe("useAsync", () => {
     });
 
     expect(onSuccess).not.toHaveBeenCalled();
-  });
-
-  it("should call the onError handler when the async function rejects", async () => {
-    const asyncFunction = () => Promise.reject("Error");
-    const onError = vi.fn();
-
-    const { result } = renderHook(() =>
-      useAsync(() => asyncFunction(), {
-        onError: (error) => onError(error),
-        manual: true,
-      })
-    );
-
-    await act(async () => {
-      result.current.run();
-      vi.advanceTimersByTime(1000);
-    });
-
-    expect(onError).toBeCalledWith("Error");
-    expect(result.current.state).toBe("rejected");
   });
 });

--- a/src/useAsync/index.tsx
+++ b/src/useAsync/index.tsx
@@ -1,28 +1,30 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { defaultOptions, handleError } from "./utils";
-import { AsyncStatus, UseAsyncOptions } from "./types";
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { asyncReducer, getInitialState } from "./utils";
+import { UseAsyncOptions } from "./types";
 
 /**
- *  The useAsync hook is a custom hook that allows you to run an async function and get the status of the promise.
- * @param fn - The async function to run.
- * @param options - The options for the hook.
- * @returns An object with the run function and the status of the promise.
+ * useAsync manages the full lifecycle of an async function: idle → pending → fulfilled | rejected.
+ *
+ * @param fn - The async function to run. Receives an AbortSignal as the last argument.
+ * @param options - Optional configuration.
+ * @returns `{ trigger, reset, status, data, error, loading }`
+ *
  * @example
- * const asyncFunction = (arg: string) => Promise.resolve(arg);
- * const { run, state } = useAsync((arg: string) => asyncFunction(arg), {manual: true});
+ * const { trigger, data, error, loading } = useAsync(fetchUser);
+ * // trigger(userId) to run manually
  *
- * const handleClick = () => run('test');
- *
+ * @example
+ * // Run on mount (fn must take no required arguments)
+ * const { data, loading } = useAsync(fetchConfig, { immediate: true });
  */
 const useAsync = <
   F extends (...args: any[]) => Promise<any>,
   T = Awaited<ReturnType<F>>
 >(
   fn: F,
-  options: UseAsyncOptions<T> = defaultOptions<T>()
+  options: UseAsyncOptions<T> = {}
 ) => {
-  const [state, setState] = useState<AsyncStatus>(AsyncStatus.Idle);
-  const isMounted = useRef(false);
+  const [state, dispatch] = useReducer(asyncReducer<T>, getInitialState<T>());
   const controllerRef = useRef<AbortController | null>(null);
 
   const fnRef = useRef(fn);
@@ -31,61 +33,52 @@ const useAsync = <
   const optionsRef = useRef(options);
   useEffect(() => { optionsRef.current = options; });
 
-  const runner = useCallback(
-    async (...args: any[]) => {
-      setState(AsyncStatus.Pending);
-      try {
-        const result = await fnRef.current(...args, {
-          signal: controllerRef?.current!.signal,
-        });
+  const trigger = useCallback(async (...args: Parameters<F>) => {
+    // Cancel any in-flight request before starting a new one
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
 
-        if (!isMounted.current) return;
+    dispatch({ type: "pending" });
 
-        setState(AsyncStatus.Fulfilled);
-        optionsRef.current.onSuccess?.(result);
-      } catch (error) {
-        setState(AsyncStatus.Rejected);
-        optionsRef.current.onError?.(error);
-      }
-    },
-    []
-  );
+    try {
+      const result = await fnRef.current(...args, { signal: controller.signal });
 
-  const autoRunner = (..._args: any[]) => {
-    throw new Error("run() is only available when the manual option is set to true");
-  };
+      if (controller.signal.aborted) return;
+
+      dispatch({ type: "fulfilled", payload: result });
+      optionsRef.current.onSuccess?.(result);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      dispatch({ type: "rejected", payload: error });
+      optionsRef.current.onError?.(error);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    dispatch({ type: "reset" });
+  }, []);
 
   useEffect(() => {
-    if (controllerRef.current == null)
-      controllerRef.current = new AbortController();
-    const controller = controllerRef.current;
-
-    isMounted.current = true;
-
-    if (options.manual) return;
-
-    runner();
+    if (options.immediate) {
+      trigger(...([] as unknown as Parameters<F>));
+    }
 
     return () => {
-      isMounted.current = false;
-      // Pospone la cancelacion de la request hasta el proximo render
-      // es para evitar que el Strict Mode cancele todo en las 2 ejecuciones del efecto
-      requestAnimationFrame(() => {
-        try {
-          if (optionsRef.current.cancelable && !isMounted.current) {
-            controller.abort();
-          }
-        } catch (e: unknown) {
-          handleError(e);
-        }
-      });
+      controllerRef.current?.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {
-    run: options.manual ? (...args: Parameters<F>) => runner(...args) : autoRunner,
-    state,
+    trigger,
+    reset,
+    status: state.status,
+    data: state.data,
+    error: state.error,
+    loading: state.status === "pending",
   };
 };
 

--- a/src/useAsync/types.ts
+++ b/src/useAsync/types.ts
@@ -1,16 +1,22 @@
-type UseAsyncOptions<T> = Partial<{
-  manual: boolean;
+export type AsyncState<T> =
+  | { status: "idle";      data: undefined; error: undefined }
+  | { status: "pending";   data: undefined; error: undefined }
+  | { status: "fulfilled"; data: T;         error: undefined }
+  | { status: "rejected";  data: undefined; error: unknown   }
+
+export type AsyncAction<T> =
+  | { type: "pending" }
+  | { type: "fulfilled"; payload: T }
+  | { type: "rejected";  payload: unknown }
+  | { type: "reset" }
+
+export type UseAsyncOptions<T> = Partial<{
+  /**
+   * If true, the async function runs automatically on mount.
+   * Only use this for functions that require no arguments.
+   * Default: false
+   */
+  immediate: boolean;
   onSuccess: (data: T) => void;
-  onError: (error: any) => void;
-  cancelable: boolean;
-}>;
-
-enum AsyncStatus {
-  Idle = "idle",
-  Pending = "pending",
-  Fulfilled = "fulfilled",
-  Rejected = "rejected",
-}
-
-export type { UseAsyncOptions };
-export { AsyncStatus };
+  onError: (error: unknown) => void;
+}>

--- a/src/useAsync/utils.ts
+++ b/src/useAsync/utils.ts
@@ -1,20 +1,23 @@
-import { UseAsyncOptions } from "./types";
+import { AsyncState, AsyncAction } from "./types";
 
-export const defaultOptions = <T>(): UseAsyncOptions<T> => ({
-  manual: false,
-  onSuccess: (_data: T) => {},
-  onError: (_error: any) => {},
-  cancelable: true,
-});
-
-export const handleError = (error: unknown) => {
-  if (!(error instanceof Error)) {
-    throw error;
+export const asyncReducer = <T>(
+  _state: AsyncState<T>,
+  action: AsyncAction<T>
+): AsyncState<T> => {
+  switch (action.type) {
+    case "pending":
+      return { status: "pending", data: undefined, error: undefined };
+    case "fulfilled":
+      return { status: "fulfilled", data: action.payload, error: undefined };
+    case "rejected":
+      return { status: "rejected", data: undefined, error: action.payload };
+    case "reset":
+      return { status: "idle", data: undefined, error: undefined };
   }
-
-  if (error.name === "AbortError") {
-    return;
-  }
-
-  throw error;
 };
+
+export const getInitialState = <T>(): AsyncState<T> => ({
+  status: "idle",
+  data: undefined,
+  error: undefined,
+});


### PR DESCRIPTION
- Replace useState string with useReducer + discriminated union (AsyncState<T>)
- Expose data, error, loading and reset in addition to status
- Rename run → trigger, manual → immediate (inverted), remove cancelable
- Fresh AbortController per trigger() call — cancels previous in-flight request
- controller.signal.aborted replaces isMounted ref check
- Remove requestAnimationFrame workaround (aborted check handles Strict Mode)
- Stabilize fn and options with refs to eliminate stale closures